### PR TITLE
Fix work heading layout

### DIFF
--- a/public/assets/css/style.css
+++ b/public/assets/css/style.css
@@ -298,6 +298,9 @@ main button {
 
 .projects h1 {
     color: white;
+    /* Ensure the section title spans the full row so it
+       always stays above the project thumbnails */
+    flex-basis: 100%;
 }
 
 .project:hover {


### PR DESCRIPTION
## Summary
- ensure the work section heading spans the entire row so it doesn't wrap unexpectedly on wide screens

## Testing
- `npm install --silent`
- `npm test --silent` *(fails: react-scripts not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844f500ccd48327ab277605654ce337