### PR TITLE
Implement honeypot spam protection for contact form

### DIFF
--- a/src/components/Contact.js
+++ b/src/components/Contact.js
@@ -2,7 +2,7 @@ import React, { useState } from 'react';
 
 function Contact() {
     const [formState, setFormState] = useState({ name: '', email: '', message: '' });
-   
+
     const { name, email, message } = formState;
 
   return (
@@ -10,9 +10,11 @@ function Contact() {
     
 
     {/* <form id="contact"> */}
-    <form id="contact-form">
+    <form id="contact-form" action="https://formspree.io/f/xnnvpner" method="POST">
         <div></div>
         <h1 className="title-name">CONTACT</h1>
+        <input type="hidden" name="_subject" value="New Contact Form Submission" />
+        <input type="text" name="_gotcha" style={{ display: "none" }} />
         
         <div className='name-box'>
             <label htmlFor="name">Name:</label>
@@ -24,13 +26,19 @@ function Contact() {
         <div className='email-box'>
             <label htmlFor="email">Email:</label>
             <br></br>
-            <input type="email" defaultValue={email} name="email" />
+            <input
+                type="email"
+                defaultValue={email}
+                name="email"
+                required
+                pattern="[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}$"
+            />
         </div>
         
         <div className='message-box'>
             <label htmlFor="message">Message:</label>
             <br></br>
-            <textarea name="message" defaultValue={message}  rows="5" />
+            <textarea name="message" defaultValue={message} rows="5" required />
         </div>
 
        


### PR DESCRIPTION
## Summary
- add Formspree action and POST method
- include hidden subject and honeypot inputs
- require valid email format and message

## Testing
- `npm test --silent`

------
https://chatgpt.com/codex/tasks/task_e_6845e6fe551083278814f7f7759b9b84